### PR TITLE
fix(security): Update dependencies for CVE-2025-66416 and CVE-2025-66418

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,11 @@ COPY requirements.txt .
 # Reference: https://peps.python.org/pep-0706/
 RUN pip install --no-cache-dir --upgrade pip>=25.0 setuptools>=78.1.1
 
-# Install core dependencies first
-RUN pip install --no-cache-dir mcp aiohttp aiohttp-cors numpy
+# Install core dependencies first (mcp>=1.23.0 for DNS rebinding protection CVE-2025-66416)
+RUN pip install --no-cache-dir "mcp>=1.23.0" aiohttp aiohttp-cors numpy
+
+# Install urllib3 with security fixes (CVE-2025-66418) before ML dependencies
+RUN pip install --no-cache-dir "urllib3>=2.6.0"
 
 # Install ML dependencies with Alpine-compatible approach
 RUN pip install --no-cache-dir \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10.12"
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.23.0",
     "starlette>=0.49.1",
 ]
 keywords = ["mcp", "context-management", "project-management", "ai-assistant", "knowledge-graph", "developer-tools", "git", "github-projects", "model-context-protocol", "persistent-memory", "thread-continuity"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,14 @@
 # Memory Journal MCP Server Dependencies
-mcp>=1.0.0
+mcp>=1.23.0  # Security fix for CVE-2025-66416 (DNS rebinding protection)
 starlette>=0.49.1  # Security fix for CVE-2025-XXXX (O(n^2) DoS via Range header)
 
 # GitHub API Integration
-requests>=2.31.0
+requests>=2.32.5
+
+# Security: urllib3 vulnerability fixes (CVE-2025-66418)
+urllib3>=2.6.0  # Fixes unbounded decompression chain and streaming API vulnerabilities
 
 # Vector Search Dependencies
-sentence-transformers>=2.2.2
+sentence-transformers>=5.1.2
 faiss-cpu>=1.7.4
 numpy>=1.21.0


### PR DESCRIPTION
## Security Updates

This PR resolves the following Dependabot security alerts:

### Alert #2: MCP Python SDK DNS Rebinding (CVE-2025-66416)
- **Package**: `mcp`
- **Fix**: Updated to `>=1.23.0`
- **Description**: The MCP Python SDK now enables DNS rebinding protection by default for HTTP-based servers running on localhost

### Alerts #3 & #4: urllib3 Decompression Vulnerabilities (CVE-2025-66418)
- **Package**: `urllib3`
- **Fix**: Added explicit `>=2.6.0` requirement
- **Description**: Fixes unbounded decompression chain and streaming API vulnerabilities that could cause excessive resource consumption

### Changes Made
- `requirements.txt`: Updated `mcp>=1.23.0`, added `urllib3>=2.6.0`, updated `sentence-transformers>=5.1.2`, `requests>=2.32.5`
- `pyproject.toml`: Updated `mcp>=1.23.0`
- `Dockerfile`: Updated pip install commands to use specific versions with security fixes

### Testing
- Docker image will be rebuilt with updated dependencies on merge