### PR TITLE
fix(docker): update tar to 7.5.7 for CVE-2026-24842

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,13 @@ RUN cd /usr/local/lib/node_modules/npm && \
     mv package node_modules/diff && \
     rm diff-8.0.3.tgz
 
-# Fix CVE-2026-23950: Manually update npm's bundled tar@7.5.3 to 7.5.4
+# Fix CVE-2026-23950 + CVE-2026-24842: Manually update npm's bundled tar to 7.5.7
 RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack tar@7.5.4 && \
+    npm pack tar@7.5.7 && \
     rm -rf node_modules/tar && \
-    tar -xzf tar-7.5.4.tgz && \
+    tar -xzf tar-7.5.7.tgz && \
     mv package node_modules/tar && \
-    rm tar-7.5.4.tgz
+    rm tar-7.5.7.tgz
 
 # Copy package files first for better layer caching
 COPY package*.json .npmrc ./
@@ -70,13 +70,13 @@ RUN cd /usr/local/lib/node_modules/npm && \
     mv package node_modules/diff && \
     rm diff-8.0.3.tgz
 
-# Fix CVE-2026-23950: Manually update npm's bundled tar@7.5.3 to 7.5.4
+# Fix CVE-2026-23950 + CVE-2026-24842: Manually update npm's bundled tar to 7.5.7
 RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack tar@7.5.4 && \
+    npm pack tar@7.5.7 && \
     rm -rf node_modules/tar && \
-    tar -xzf tar-7.5.4.tgz && \
+    tar -xzf tar-7.5.7.tgz && \
     mv package node_modules/tar && \
-    rm tar-7.5.4.tgz
+    rm tar-7.5.7.tgz
 
 # Copy built artifacts and production dependencies
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Summary

Fixes Docker Scout security scan failure due to CVE-2026-24842 in tar 7.5.4.

## Changes

- Updated Dockerfile tar patches from 7.5.4 to 7.5.7 in both builder and production stages
- Fixes HIGH severity path traversal vulnerability (CVSS 8.2)

## Testing

Docker Scout security scan should now pass.