### PR TITLE
feat: add --server-host CLI option and MCP_HOST env var

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -1,6 +1,6 @@
 # Memory Journal MCP Server
 
-**Last Updated: February 5, 2026**
+**Last Updated February 13, 2026**
 
 [![GitHub](https://img.shields.io/badge/GitHub-neverinfamous/memory--journal--mcp-blue?logo=github)](https://github.com/neverinfamous/memory-journal-mcp)
 [![Docker Pulls](https://img.shields.io/docker/pulls/writenotenow/memory-journal-mcp)](https://hub.docker.com/r/writenotenow/memory-journal-mcp)
@@ -204,7 +204,7 @@ For remote access, web-based clients, or HTTP-compatible MCP hosts:
 docker run --rm -p 3000:3000 \
   -v ./data:/app/data \
   writenotenow/memory-journal-mcp:latest \
-  --transport http --port 3000
+  --transport http --port 3000 --server-host 0.0.0.0
 ```
 
 **Stateless Mode (serverless):**
@@ -213,7 +213,7 @@ docker run --rm -p 3000:3000 \
 docker run --rm -p 3000:3000 \
   -v ./data:/app/data \
   writenotenow/memory-journal-mcp:latest \
-  --transport http --port 3000 --stateless
+  --transport http --port 3000 --server-host 0.0.0.0 --stateless
 ```
 
 **Endpoints:**
@@ -352,6 +352,9 @@ Including `memory://briefing` for session initialization, `memory://instructions
 
 # Tool filtering (optional - control which tools are exposed)
 -e MEMORY_JOURNAL_MCP_TOOL_FILTER="-github"
+
+# Server bind host (required for containers, default: localhost)
+-e MCP_HOST=0.0.0.0
 
 # Database location
 -e DB_PATH=/app/data/custom.db

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Memory Journal MCP Server
 
-**Last Updated: February 5, 2026**
+**Last Updated February 13, 2026**
 
 <!-- mcp-name: io.github.neverinfamous/memory-journal-mcp -->
 
@@ -182,6 +182,12 @@ For remote access or web-based clients, run the server in HTTP mode:
 memory-journal-mcp --transport http --port 3000
 ```
 
+To bind to all interfaces (required for containers):
+
+```bash
+memory-journal-mcp --transport http --port 3000 --server-host 0.0.0.0
+```
+
 **Endpoints:**
 
 - `POST /mcp` — JSON-RPC requests (initialize, tools/call, etc.)
@@ -247,6 +253,7 @@ The GitHub tools (`get_github_issues`, `get_github_prs`, etc.) can auto-detect t
 | `GITHUB_REPO_PATH`       | Path to the git repository for auto-detecting owner/repo               |
 | `DEFAULT_PROJECT_NUMBER` | Default GitHub Project number for auto-assignment when creating issues |
 | `AUTO_REBUILD_INDEX`     | Set to `true` to rebuild vector index on server startup                |
+| `MCP_HOST`               | Server bind host (`0.0.0.0` for containers, default: `localhost`)      |
 
 **Without `GITHUB_REPO_PATH`**: You'll need to explicitly provide `owner` and `repo` parameters when calling GitHub tools.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ program
     .version(pkg.version)
     .option('--transport <type>', 'Transport type: stdio or http', 'stdio')
     .option('--port <number>', 'HTTP port (for http transport)', '3000')
+    .option('--server-host <host>', 'Server bind host for HTTP transport (default: localhost)')
     .option('--stateless', 'Use stateless HTTP mode (no session management)')
     .option('--db <path>', 'Database path', './memory_journal.db')
     .option('--tool-filter <filter>', 'Tool filter string (e.g., "starter", "core,search")')
@@ -25,6 +26,7 @@ program
         async (options: {
             transport: string
             port: string
+            serverHost?: string
             stateless?: boolean
             db: string
             toolFilter?: string
@@ -35,17 +37,23 @@ program
             // Set log level
             logger.setLevel(options.logLevel as 'debug' | 'info' | 'warning' | 'error')
 
+            // Resolve host: CLI flag > env var > default (localhost)
+            const host =
+                options.serverHost ?? process.env['MCP_HOST'] ?? process.env['HOST'] ?? undefined
+
             logger.info('Starting Memory Journal MCP Server', {
                 module: 'CLI',
                 transport: options.transport,
                 stateless: options.stateless ?? false,
                 db: options.db,
+                ...(host ? { host } : {}),
             })
 
             try {
                 await createServer({
                     transport: options.transport as 'stdio' | 'http',
                     port: parseInt(options.port, 10),
+                    host,
                     statelessHttp: options.stateless === true,
                     dbPath: options.db,
                     toolFilter: options.toolFilter,

--- a/src/server/McpServer.ts
+++ b/src/server/McpServer.ts
@@ -34,6 +34,7 @@ import pkg from '../../package.json' with { type: 'json' }
 export interface ServerOptions {
     transport: 'stdio' | 'http'
     port?: number
+    host?: string
     dbPath: string
     toolFilter?: string
     defaultProjectNumber?: number
@@ -394,6 +395,7 @@ export async function createServer(options: ServerOptions): Promise<void> {
     } else {
         // HTTP transport with SSE support
         const port = options.port ?? 3000
+        const host = options.host ?? 'localhost'
         const app: Express = express()
 
         // Manual CORS middleware for browser-based clients (e.g., MCP Inspector)
@@ -479,11 +481,12 @@ export async function createServer(options: ServerOptions): Promise<void> {
             })
 
             // Start HTTP server
-            const httpServer = app.listen(port, () => {
+            const httpServer = app.listen(port, host, () => {
                 logger.info('MCP server started on HTTP (stateless)', {
                     module: 'McpServer',
                     port,
-                    endpoint: `http://localhost:${port}/mcp`,
+                    host,
+                    endpoint: `http://${host}:${port}/mcp`,
                 })
             })
 
@@ -656,11 +659,12 @@ export async function createServer(options: ServerOptions): Promise<void> {
             })
 
             // Start HTTP server
-            const httpServer = app.listen(port, () => {
+            const httpServer = app.listen(port, host, () => {
                 logger.info('MCP server started on HTTP (stateful)', {
                     module: 'McpServer',
                     port,
-                    endpoint: `http://localhost:${port}/mcp`,
+                    host,
+                    endpoint: `http://${host}:${port}/mcp`,
                 })
             })
 


### PR DESCRIPTION
Adds --server-host CLI option and MCP_HOST environment variable for configuring the HTTP transport bind address. Essential for containerized deployments where the server must bind to 