### PR TITLE
fix: update qs 6.14.1 to 6.14.2 (GHSA-w7fw-mjwx-w883)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4893,9 +4893,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.14.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+            "version": "6.14.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"


### PR DESCRIPTION
Updates qs from 6.14.1 to 6.14.2 to fix low-severity arrayLimit bypass in comma parsing that allows denial of service (GHSA-w7fw-mjwx-w883).