### PR TITLE
v4.4.1 - CVE Remediation (minimatch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.4.1] - 2026-02-27
+
 ### Security
 
 - **CVE-2026-27903 + CVE-2026-27904 (minimatch)** — Added npm override `minimatch@^10.2.3` to fix HIGH severity ReDoS and algorithmic complexity vulnerabilities (CVSS 7.5) that blocked Docker deploy

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -466,7 +466,7 @@ Memory Journal is designed for extremely low overhead during AI task execution.
 
 **Available Tags:**
 
-- `4.4.0` - Specific version (recommended for production)
+- `4.4.1` - Specific version (recommended for production)
 - `4.4` - Latest patch in 4.4.x series
 - `4` - Latest minor in 4.x series
 - `latest` - Always the newest version

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,6 @@ CMD ["node", "dist/cli.js"]
 # Labels for Docker Hub
 LABEL maintainer="Adamic.tech"
 LABEL description="Memory Journal MCP Server - Project context management for AI-assisted development"
-LABEL version="4.4.0"
+LABEL version="4.4.1"
 LABEL org.opencontainers.image.source="https://github.com/neverinfamous/memory-journal-mcp"
 LABEL io.modelcontextprotocol.server.name="io.github.neverinfamous/memory-journal-mcp"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "memory-journal-mcp",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "memory-journal-mcp",
-            "version": "4.4.0",
+            "version": "4.4.1",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "memory-journal-mcp",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "description": "Project context management for AI-assisted development - Persistent knowledge graphs and intelligent context recall across fragmented AI threads",
     "type": "module",
     "main": "dist/index.js",

--- a/releases/v4.4.1.md
+++ b/releases/v4.4.1.md
@@ -1,0 +1,33 @@
+# v4.4.1 - CVE Remediation (minimatch)
+
+Released: February 27, 2026
+
+## Highlights
+
+- **Security Patch** — Fixed 2 HIGH severity CVEs in minimatch that blocked Docker deployment
+
+---
+
+## Security
+
+### CVE-2026-27903 (minimatch) — HIGH
+
+Inefficient algorithmic complexity vulnerability in minimatch >=10.0.0, <10.2.3 (CVSS 7.5). Added npm override `minimatch@^10.2.3`.
+
+### CVE-2026-27904 (minimatch) — HIGH
+
+Inefficient regular expression complexity (ReDoS) in minimatch >=10.0.0, <10.2.3 (CVSS 7.5). Same fix as CVE-2026-27903.
+
+---
+
+## Upgrade
+
+```bash
+# npm
+npm update -g memory-journal-mcp
+
+# Docker
+docker pull writenotenow/memory-journal-mcp:v4.4.1
+```
+
+**Full Changelog**: https://github.com/neverinfamous/memory-journal-mcp/wiki/CHANGELOG

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
     "name": "io.github.neverinfamous/memory-journal-mcp",
     "title": "Memory Journal MCP",
     "description": "MCP server– Project memory system with GitHub-aware context, knowledge graphs, and CI/PR timelines",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "packages": [
         {
             "registryType": "oci",
-            "identifier": "docker.io/writenotenow/memory-journal-mcp:v4.4.0",
-            "version": "4.4.0",
+            "identifier": "docker.io/writenotenow/memory-journal-mcp:v4.4.1",
+            "version": "4.4.1",
             "transport": {
                 "type": "stdio"
             }


### PR DESCRIPTION
# v4.4.1 - CVE Remediation (minimatch)

Released: February 27, 2026

## Highlights

- **Security Patch** — Fixed 2 HIGH severity CVEs in minimatch that blocked Docker deployment

---

## Security

### CVE-2026-27903 (minimatch) — HIGH

Inefficient algorithmic complexity vulnerability in minimatch >=10.0.0, <10.2.3 (CVSS 7.5). Added npm override `minimatch@^10.2.3`.

### CVE-2026-27904 (minimatch) — HIGH

Inefficient regular expression complexity (ReDoS) in minimatch >=10.0.0, <10.2.3 (CVSS 7.5). Same fix as CVE-2026-27903.

---

## Upgrade

```bash
# npm
npm update -g memory-journal-mcp

# Docker
docker pull writenotenow/memory-journal-mcp:v4.4.1
```

**Full Changelog**: https://github.com/neverinfamous/memory-journal-mcp/wiki/CHANGELOG
