### PR TITLE
v4.4.2 - CVE Remediation: patch npm bundled minimatch in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.4.1] - 2026-02-27
+## [4.4.2] - 2026-02-27
 
 ### Security
 
-- **CVE-2026-27903 + CVE-2026-27904 (minimatch)** — Added npm override `minimatch@^10.2.3` to fix HIGH severity ReDoS and algorithmic complexity vulnerabilities (CVSS 7.5) that blocked Docker deploy
+- **CVE-2026-27903 + CVE-2026-27904 (minimatch)** — Manually patched npm's bundled `minimatch` → `10.2.3` in Dockerfile to fix HIGH severity ReDoS and algorithmic complexity vulnerabilities (CVSS 7.5). The v4.4.1 npm override only affected project dependencies; Docker Scout detected the vulnerable copy inside npm's own bundled packages. Also added npm override.
 
 ## [4.4.0] - 2026-02-27
 

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -466,7 +466,7 @@ Memory Journal is designed for extremely low overhead during AI task execution.
 
 **Available Tags:**
 
-- `4.4.1` - Specific version (recommended for production)
+- `4.4.2` - Specific version (recommended for production)
 - `4.4` - Latest patch in 4.4.x series
 - `4` - Latest minor in 4.x series
 - `latest` - Always the newest version

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,14 @@ RUN cd /usr/local/lib/node_modules/npm && \
     mv package node_modules/tar && \
     rm tar-7.5.8.tgz
 
+# Fix CVE-2026-27903, CVE-2026-27904: Manually update npm's bundled minimatch to 10.2.3
+RUN cd /usr/local/lib/node_modules/npm && \
+    npm pack minimatch@10.2.3 && \
+    rm -rf node_modules/minimatch && \
+    tar -xzf minimatch-10.2.3.tgz && \
+    mv package node_modules/minimatch && \
+    rm minimatch-10.2.3.tgz
+
 # Copy package files first for better layer caching
 COPY package*.json .npmrc ./
 
@@ -78,6 +86,14 @@ RUN cd /usr/local/lib/node_modules/npm && \
     mv package node_modules/tar && \
     rm tar-7.5.8.tgz
 
+# Fix CVE-2026-27903, CVE-2026-27904: Manually update npm's bundled minimatch to 10.2.3
+RUN cd /usr/local/lib/node_modules/npm && \
+    npm pack minimatch@10.2.3 && \
+    rm -rf node_modules/minimatch && \
+    tar -xzf minimatch-10.2.3.tgz && \
+    mv package node_modules/minimatch && \
+    rm minimatch-10.2.3.tgz
+
 # Copy built artifacts and production dependencies
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
@@ -110,6 +126,6 @@ CMD ["node", "dist/cli.js"]
 # Labels for Docker Hub
 LABEL maintainer="Adamic.tech"
 LABEL description="Memory Journal MCP Server - Project context management for AI-assisted development"
-LABEL version="4.4.1"
+LABEL version="4.4.2"
 LABEL org.opencontainers.image.source="https://github.com/neverinfamous/memory-journal-mcp"
 LABEL io.modelcontextprotocol.server.name="io.github.neverinfamous/memory-journal-mcp"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "memory-journal-mcp",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "memory-journal-mcp",
-            "version": "4.4.1",
+            "version": "4.4.2",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "memory-journal-mcp",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "description": "Project context management for AI-assisted development - Persistent knowledge graphs and intelligent context recall across fragmented AI threads",
     "type": "module",
     "main": "dist/index.js",

--- a/releases/v4.4.2.md
+++ b/releases/v4.4.2.md
@@ -1,0 +1,31 @@
+# v4.4.2 - CVE Remediation (minimatch Dockerfile Patch)
+
+Released: February 27, 2026
+
+## Highlights
+
+- **Docker CVE Fix** — Manually patched npm's bundled minimatch in Dockerfile to resolve Docker deploy block
+
+---
+
+## Security
+
+### CVE-2026-27903 + CVE-2026-27904 (minimatch) — HIGH
+
+Manually patched npm's bundled `minimatch@10.2.2` → `10.2.3` in Dockerfile to fix HIGH severity ReDoS and algorithmic complexity vulnerabilities (CVSS 7.5).
+
+The v4.4.1 npm override only affected project dependencies. Docker Scout detected the vulnerable copy inside npm's own bundled packages at `/usr/local/lib/node_modules/npm/node_modules/minimatch`. This follows the same manual patch pattern used for tar and diff CVEs.
+
+---
+
+## Upgrade
+
+```bash
+# npm
+npm update -g memory-journal-mcp
+
+# Docker
+docker pull writenotenow/memory-journal-mcp:v4.4.2
+```
+
+**Full Changelog**: https://github.com/neverinfamous/memory-journal-mcp/wiki/CHANGELOG

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
     "name": "io.github.neverinfamous/memory-journal-mcp",
     "title": "Memory Journal MCP",
     "description": "MCP server– Project memory system with GitHub-aware context, knowledge graphs, and CI/PR timelines",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "packages": [
         {
             "registryType": "oci",
-            "identifier": "docker.io/writenotenow/memory-journal-mcp:v4.4.1",
-            "version": "4.4.1",
+            "identifier": "docker.io/writenotenow/memory-journal-mcp:v4.4.2",
+            "version": "4.4.2",
             "transport": {
                 "type": "stdio"
             }


### PR DESCRIPTION
# v4.4.2 - CVE Remediation (minimatch Dockerfile Patch)

Released: February 27, 2026

## Highlights

- **Docker CVE Fix** — Manually patched npm's bundled minimatch in Dockerfile to resolve Docker deploy block

---

## Security

### CVE-2026-27903 + CVE-2026-27904 (minimatch) — HIGH

Manually patched npm's bundled `minimatch@10.2.2` → `10.2.3` in Dockerfile to fix HIGH severity ReDoS and algorithmic complexity vulnerabilities (CVSS 7.5).

The v4.4.1 npm override only affected project dependencies. Docker Scout detected the vulnerable copy inside npm's own bundled packages at `/usr/local/lib/node_modules/npm/node_modules/minimatch`. This follows the same manual patch pattern used for tar and diff CVEs.

---

## Upgrade

```bash
# npm
npm update -g memory-journal-mcp

# Docker
docker pull writenotenow/memory-journal-mcp:v4.4.2
```

**Full Changelog**: https://github.com/neverinfamous/memory-journal-mcp/wiki/CHANGELOG
