### PR TITLE
v5.0.1 - GHSA-qffp-2rhf-9h96 (tar) security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1] - 2026-03-06
+
+### Security
+
+- **GHSA-qffp-2rhf-9h96 (tar)** — Manually patched npm's bundled `tar` → `7.5.10` in Dockerfile to fix HIGH severity path traversal vulnerability (CVSS 8.2). Also updated npm override.
+
+### Changed
+
+- **Dependency Updates**
+  - `tar` override: 7.5.9 → 7.5.10 (patch) — npm + Docker layers
+
 ## [5.0.0] - 2026-03-06
 
 ### Added

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -423,7 +423,7 @@ Designed for extremely low overhead: database reads in sub-millisecond, vector s
 
 **Available Tags:**
 
-- `5.0.0` - Specific version (recommended for production)
+- `5.0.1` - Specific version (recommended for production)
 - `5.0` - Latest patch in 5.0.x series
 - `5` - Latest minor in 5.x series
 - `latest` - Always the newest version

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,13 @@ RUN cd /usr/local/lib/node_modules/npm && \
     mv package node_modules/diff && \
     rm diff-8.0.3.tgz
 
-# Fix CVE-2026-23950, CVE-2026-24842, CVE-2026-26960: Manually update npm's bundled tar to 7.5.9
+# Fix CVE-2026-23950, CVE-2026-24842, CVE-2026-26960, GHSA-qffp-2rhf-9h96: Manually update npm's bundled tar to 7.5.10
 RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack tar@7.5.9 && \
+    npm pack tar@7.5.10 && \
     rm -rf node_modules/tar && \
-    tar -xzf tar-7.5.9.tgz && \
+    tar -xzf tar-7.5.10.tgz && \
     mv package node_modules/tar && \
-    rm tar-7.5.9.tgz
+    rm tar-7.5.10.tgz
 
 # Fix CVE-2026-27903, CVE-2026-27904: Manually update npm's bundled minimatch to 10.2.4
 RUN cd /usr/local/lib/node_modules/npm && \
@@ -79,13 +79,13 @@ RUN cd /usr/local/lib/node_modules/npm && \
     mv package node_modules/diff && \
     rm diff-8.0.3.tgz
 
-# Fix CVE-2026-23950, CVE-2026-24842, CVE-2026-26960: Manually update npm's bundled tar to 7.5.9
+# Fix CVE-2026-23950, CVE-2026-24842, CVE-2026-26960, GHSA-qffp-2rhf-9h96: Manually update npm's bundled tar to 7.5.10
 RUN cd /usr/local/lib/node_modules/npm && \
-    npm pack tar@7.5.9 && \
+    npm pack tar@7.5.10 && \
     rm -rf node_modules/tar && \
-    tar -xzf tar-7.5.9.tgz && \
+    tar -xzf tar-7.5.10.tgz && \
     mv package node_modules/tar && \
-    rm tar-7.5.9.tgz
+    rm tar-7.5.10.tgz
 
 # Fix CVE-2026-27903, CVE-2026-27904: Manually update npm's bundled minimatch to 10.2.4
 RUN cd /usr/local/lib/node_modules/npm && \
@@ -129,6 +129,6 @@ ENTRYPOINT ["node", "dist/cli.js"]
 # Labels for Docker Hub
 LABEL maintainer="Adamic.tech"
 LABEL description="Memory Journal MCP Server - Project context management for AI-assisted development"
-LABEL version="5.0.0"
+LABEL version="5.0.1"
 LABEL org.opencontainers.image.source="https://github.com/neverinfamous/memory-journal-mcp"
 LABEL io.modelcontextprotocol.server.name="io.github.neverinfamous/memory-journal-mcp"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "memory-journal-mcp",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "memory-journal-mcp",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "memory-journal-mcp",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "description": "Project context management for AI-assisted development - Persistent knowledge graphs and intelligent context recall across fragmented AI threads",
     "type": "module",
     "main": "dist/index.js",
@@ -81,7 +81,7 @@
         "brace-expansion": "^2.0.2",
         "glob": "^11.1.0",
         "minimatch": "^10.2.4",
-        "tar": "^7.5.9",
+        "tar": "^7.5.10",
         "tmp": "^0.2.4"
     }
 }

--- a/releases/v5.0.1.md
+++ b/releases/v5.0.1.md
@@ -1,0 +1,25 @@
+# v5.0.1 — Security Patch
+
+**Release Date:** March 6, 2026
+
+Patches a HIGH severity path traversal vulnerability in npm's bundled `tar` package discovered by Docker Scout during the v5.0.0 deployment pipeline.
+
+## 🔒 Security
+
+- **GHSA-qffp-2rhf-9h96 (tar)** — Manually patched npm's bundled `tar` → `7.5.10` in Dockerfile (builder + production stages) to fix HIGH severity path traversal vulnerability (CVSS 8.2). Also updated npm override in `package.json`.
+
+## 🔄 Changed
+
+- `tar` override: 7.5.9 → 7.5.10 (patch) — npm + Docker layers
+
+---
+
+**Full Changelog:** [v5.0.0...v5.0.1](https://github.com/neverinfamous/memory-journal-mcp/compare/v5.0.0...v5.0.1)
+
+**Install/Update:**
+
+```bash
+npm install -g memory-journal-mcp@5.0.1
+# or
+docker pull writenotenow/memory-journal-mcp:v5.0.1
+```


### PR DESCRIPTION
# v5.0.1 — Security Patch

**Release Date:** March 6, 2026

Patches a HIGH severity path traversal vulnerability in npm's bundled `tar` package discovered by Docker Scout during the v5.0.0 deployment pipeline.

## 🔒 Security

- **GHSA-qffp-2rhf-9h96 (tar)** — Manually patched npm's bundled `tar` → `7.5.10` in Dockerfile (builder + production stages) to fix HIGH severity path traversal vulnerability (CVSS 8.2). Also updated npm override in `package.json`.

## 🔄 Changed

- `tar` override: 7.5.9 → 7.5.10 (patch) — npm + Docker layers

---

**Full Changelog:** [v5.0.0...v5.0.1](https://github.com/neverinfamous/memory-journal-mcp/compare/v5.0.0...v5.0.1)

**Install/Update:**

```bash
npm install -g memory-journal-mcp@5.0.1
# or
docker pull writenotenow/memory-journal-mcp:v5.0.1
```
