### PR TITLE
v6.1.2 - Remaining CodeQL fixes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,12 +32,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          # Pin to the exact commit that passed Lint and Test (deterministic).
-          # persist-credentials: false strips the GITHUB_TOKEN from git config,
-          # satisfying CodeQL's untrusted-checkout concern (no write token exposure).
-          ref: ${{ github.event.workflow_run.head_sha }}
-          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -97,9 +91,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -180,9 +171,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          persist-credentials: false
 
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to Memory Journal MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/neverinfamous/memory-journal-mcp/compare/v6.1.1...HEAD)
+## [Unreleased](https://github.com/neverinfamous/memory-journal-mcp/compare/v6.1.2...HEAD)
+
+## [6.1.2](https://github.com/neverinfamous/memory-journal-mcp/releases/tag/v6.1.2) - 2026-03-22
+
+### Security
+
+- **Docker Workflow** — Removed `ref: ${{ github.event.workflow_run.head_sha }}` from `docker-publish.yml` checkout steps; CodeQL does not accept `persist-credentials: false` as mitigation for untrusted-checkout alerts (#145, #146, #161).
+
+### Fixed
+
+- **Unused Import** — Removed orphaned `jose` import from `entries-auth-branches.test.ts` (#162), cascading from v6.1.1 `err` variable removal.
 
 ## [6.1.1](https://github.com/neverinfamous/memory-journal-mcp/releases/tag/v6.1.1) - 2026-03-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "memory-journal-mcp",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "memory-journal-mcp",
-            "version": "6.1.1",
+            "version": "6.1.2",
             "license": "MIT",
             "dependencies": {
                 "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "memory-journal-mcp",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "description": "Project context management for AI-assisted development - Persistent knowledge graphs and intelligent context recall across fragmented AI threads",
     "type": "module",
     "main": "dist/index.js",

--- a/releases/v6.1.2.md
+++ b/releases/v6.1.2.md
@@ -1,0 +1,23 @@
+# v6.1.2 — CodeQL Cleanup (Follow-up)
+
+Resolves 4 remaining CodeQL alerts from v6.1.1: 3 Docker workflow untrusted-checkout and 1 unused import.
+
+## Security
+
+- Remove `ref: ${{ github.event.workflow_run.head_sha }}` from `docker-publish.yml` checkout steps — CodeQL does not accept `persist-credentials: false` as mitigation (#145, #146, #161)
+
+## Fixed
+
+- Remove orphaned `jose` import from `entries-auth-branches.test.ts` (#162), cascading from v6.1.1 `err` variable removal
+
+---
+
+**Compare**: [`v6.1.1...v6.1.2`](https://github.com/neverinfamous/memory-journal-mcp/compare/v6.1.1...v6.1.2)
+
+```bash
+npm install -g memory-journal-mcp@6.1.2
+```
+
+```bash
+docker pull writenotenow/memory-journal-mcp:v6.1.2
+```

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
     "name": "io.github.neverinfamous/memory-journal-mcp",
     "title": "Memory Journal MCP",
     "description": "Persistent knowledge graphs and intelligent context recall across AI threads",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "packages": [
         {
             "registryType": "oci",
-            "identifier": "docker.io/writenotenow/memory-journal-mcp:v6.1.1",
-            "version": "6.1.1",
+            "identifier": "docker.io/writenotenow/memory-journal-mcp:v6.1.2",
+            "version": "6.1.2",
             "transport": {
                 "type": "stdio"
             }

--- a/tests/database/entries-auth-branches.test.ts
+++ b/tests/database/entries-auth-branches.test.ts
@@ -9,7 +9,6 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import * as jose from 'jose'
 import Database from 'better-sqlite3'
 
 vi.mock('../../src/utils/logger.js', () => ({


### PR DESCRIPTION
# v6.1.2 — CodeQL Cleanup (Follow-up)

Resolves 4 remaining CodeQL alerts from v6.1.1: 3 Docker workflow untrusted-checkout and 1 unused import.

## Security

- Remove `ref: ${{ github.event.workflow_run.head_sha }}` from `docker-publish.yml` checkout steps — CodeQL does not accept `persist-credentials: false` as mitigation (#145, #146, #161)

## Fixed

- Remove orphaned `jose` import from `entries-auth-branches.test.ts` (#162), cascading from v6.1.1 `err` variable removal

---

**Compare**: [`v6.1.1...v6.1.2`](https://github.com/neverinfamous/memory-journal-mcp/compare/v6.1.1...v6.1.2)

```bash
npm install -g memory-journal-mcp@6.1.2
```

```bash
docker pull writenotenow/memory-journal-mcp:v6.1.2
```
