### PR TITLE
security: disable OIDC token minting in HOL skill-validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,33 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - skills/github-commander/**
+      - .github/workflows/hol-skill-validate.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - skills/github-commander/**
+      - .github/workflows/hol-skill-validate.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: none
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@47895cf40f6214511c713628dbbafd0c3316f4dd
+        with:
+          mode: validate
+          skill-dir: skills/github-commander
+          annotate: 'false'
+          preview-upload: 'false'


### PR DESCRIPTION
This adds `id-token: none` to the HOL skill-validate workflow permissions, explicitly disabling GitHub OIDC token minting.

The validate-only workflow has no need for OIDC tokens. This is a defensive permission to prevent any possibility of token exfiltration.
