### PR TITLE
chore: resolve unused variable warnings in test coverage

### DIFF
--- a/tests/handlers/team-io-tools.test.ts
+++ b/tests/handlers/team-io-tools.test.ts
@@ -79,10 +79,10 @@ describe('getTeamIoTools', () => {
                 (t) => t.name === 'team_export_markdown'
             )!.handler
 
-            const result = (await handler({
+            await handler({
                 output_dir: '/tmp/team-out',
                 start_date: '2025-01-01',
-            })) as any
+            })
             expect((context.teamDb as any).searchByDateRange).toHaveBeenCalled()
         })
 

--- a/tests/handlers/utilities-coverage.test.ts
+++ b/tests/handlers/utilities-coverage.test.ts
@@ -19,7 +19,7 @@ describe('utilities coverage', () => {
         try {
             let time = Date.now()
             vi.spyOn(Date, 'now').mockImplementation(() => time)
-            const statSpy = vi.spyOn(fs.promises, 'stat').mockResolvedValue({ mtimeMs: 1234 } as any)
+            vi.spyOn(fs.promises, 'stat').mockResolvedValue({ mtimeMs: 1234 } as any)
             const readFileSpy = vi.spyOn(fs.promises, 'readFile').mockResolvedValue('rules content')
 
             // 1. Initial read


### PR DESCRIPTION
Resolves two CodeQL alerts for unused variables (statSpy and result) inside the test suites.