### PR TITLE
chore(release): v7.6.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,15 +26,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        uses: github/codeql-action/init@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        uses: github/codeql-action/autobuild@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        uses: github/codeql-action/analyze@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         with:
           upload: always

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Attest Build Provenance
         if: github.ref == 'refs/heads/main'
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/secrets-scanning.yml
+++ b/.github/workflows/secrets-scanning.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog Secret Scanning
-        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
         with:
           path: ./
           base: ${{ github.event.before || 'HEAD~1' }}

--- a/.github/workflows/security-update.yml
+++ b/.github/workflows/security-update.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Run SARIF scan first (non-blocking) to always generate the file
       - name: Run Trivy scanner for SARIF output
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: security-test:latest
           format: 'sarif'
@@ -54,14 +54,14 @@ jobs:
           skip-dirs: '/usr/local/lib/node_modules/npm'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: 'trivy-results.sarif'
 
       # Run table scan (blocking) after SARIF is uploaded
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: security-test:latest
           format: 'table'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,6 @@ All notable changes to Memory Journal MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/neverinfamous/memory-journal-mcp/compare/v7.6.0...HEAD)
-
-### Fixed
-
-- Code Mode and standard test failures when creating, resolving, or searching global team flags by resolving strict `project_number` nullish schema validation errors.
-- Internal crash in `team_search` and `team_search_by_date_range` when filtering global flags by conditionally bypassing the strict multi-tenant `project_number` requirements when explicitly searching for `flag:` tags or `entry_type === 'flag'`.
-
 ## [7.6.0](https://github.com/neverinfamous/memory-journal-mcp/releases/tag/v7.6.0) - 2026-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Memory Journal MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/neverinfamous/memory-journal-mcp/compare/v7.6.1...HEAD)
+
+## [7.6.1](https://github.com/neverinfamous/memory-journal-mcp/releases/tag/v7.6.1) - 2026-04-22
+
+### Fixed
+
+- Code Mode and standard test failures when creating, resolving, or searching global team flags by resolving strict `project_number` nullish schema validation errors.
+- Internal crash in `team_search` and `team_search_by_date_range` when filtering global flags by conditionally bypassing the strict multi-tenant `project_number` requirements when explicitly searching for `flag:` tags or `entry_type === 'flag'`.
+
+### Dependencies
+
+- Bumped `aquasecurity/trivy-action` from `v0.35.0` to `v0.36.0`.
+- Bumped `github/codeql-action` from `v4.35.1` to `v4.35.2`.
+- Bumped `trufflesecurity/trufflehog` from `v3.94.3` to `v3.95.2`.
+- Bumped `actions/attest-build-provenance` from `v2` to `v4.1.0` (SHA-pinned).
+
 ## [7.6.0](https://github.com/neverinfamous/memory-journal-mcp/releases/tag/v7.6.0) - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ Control which tools are exposed via `MEMORY_JOURNAL_MCP_TOOL_FILTER` (or CLI: `-
 - `session-summary` - Create a session summary entry with accomplishments, pending items, and next-session context
 - `team-session-summary` - Create a retrospective team session summary entry securely isolated to the team database
 
-
 **[Complete prompts guide →](https://github.com/neverinfamous/memory-journal-mcp/wiki/Prompts)**
 
 ### 📡 **36 Resources** (27 Static + 9 Template)

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,11 @@
 # Unreleased Changes
 
 ## [Unreleased](https://github.com/neverinfamous/memory-journal-mcp/compare/v7.6.0...HEAD)
+
+### Dependencies
+
+- Bumped `aquasecurity/trivy-action` from `v0.35.0` to `v0.36.0`.
+- Bumped `github/codeql-action` from `v4.35.1` to `v4.35.2`.
+- Bumped `trufflesecurity/trufflehog` from `v3.94.3` to `v3.95.2`.
+- Bumped `actions/attest-build-provenance` from `v2` to `v4.1.0` (SHA-pinned).
+

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased](https://github.com/neverinfamous/memory-journal-mcp/compare/v7.6.0...HEAD)
 
+<<<<<<< Updated upstream
 ### Dependencies
 
 - Bumped `aquasecurity/trivy-action` from `v0.35.0` to `v0.36.0`.
@@ -9,3 +10,9 @@
 - Bumped `trufflesecurity/trufflehog` from `v3.94.3` to `v3.95.2`.
 - Bumped `actions/attest-build-provenance` from `v2` to `v4.1.0` (SHA-pinned).
 
+=======
+### Fixed
+
+- Code Mode and standard test failures when creating, resolving, or searching global team flags by resolving strict `project_number` nullish schema validation errors.
+- Internal crash in `team_search` and `team_search_by_date_range` when filtering global flags by conditionally bypassing the strict multi-tenant `project_number` requirements when explicitly searching for `flag:` tags or `entry_type === 'flag'`.
+>>>>>>> Stashed changes

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,15 +1,3 @@
 # Unreleased Changes
 
-## [Unreleased](https://github.com/neverinfamous/memory-journal-mcp/compare/v7.6.0...HEAD)
-
-### Fixed
-
-- Code Mode and standard test failures when creating, resolving, or searching global team flags by resolving strict `project_number` nullish schema validation errors.
-- Internal crash in `team_search` and `team_search_by_date_range` when filtering global flags by conditionally bypassing the strict multi-tenant `project_number` requirements when explicitly searching for `flag:` tags or `entry_type === 'flag'`.
-
-### Dependencies
-
-- Bumped `aquasecurity/trivy-action` from `v0.35.0` to `v0.36.0`.
-- Bumped `github/codeql-action` from `v4.35.1` to `v4.35.2`.
-- Bumped `trufflesecurity/trufflehog` from `v3.94.3` to `v3.95.2`.
-- Bumped `actions/attest-build-provenance` from `v2` to `v4.1.0` (SHA-pinned).
+## [Unreleased](https://github.com/neverinfamous/memory-journal-mcp/compare/v7.6.1...HEAD)

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,17 +2,14 @@
 
 ## [Unreleased](https://github.com/neverinfamous/memory-journal-mcp/compare/v7.6.0...HEAD)
 
-<<<<<<< Updated upstream
+### Fixed
+
+- Code Mode and standard test failures when creating, resolving, or searching global team flags by resolving strict `project_number` nullish schema validation errors.
+- Internal crash in `team_search` and `team_search_by_date_range` when filtering global flags by conditionally bypassing the strict multi-tenant `project_number` requirements when explicitly searching for `flag:` tags or `entry_type === 'flag'`.
+
 ### Dependencies
 
 - Bumped `aquasecurity/trivy-action` from `v0.35.0` to `v0.36.0`.
 - Bumped `github/codeql-action` from `v4.35.1` to `v4.35.2`.
 - Bumped `trufflesecurity/trufflehog` from `v3.94.3` to `v3.95.2`.
 - Bumped `actions/attest-build-provenance` from `v2` to `v4.1.0` (SHA-pinned).
-
-=======
-### Fixed
-
-- Code Mode and standard test failures when creating, resolving, or searching global team flags by resolving strict `project_number` nullish schema validation errors.
-- Internal crash in `team_search` and `team_search_by_date_range` when filtering global flags by conditionally bypassing the strict multi-tenant `project_number` requirements when explicitly searching for `flag:` tags or `entry_type === 'flag'`.
->>>>>>> Stashed changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "memory-journal-mcp",
-    "version": "7.6.0",
+    "version": "7.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "memory-journal-mcp",
-            "version": "7.6.0",
+            "version": "7.6.1",
             "license": "MIT",
             "dependencies": {
                 "@huggingface/transformers": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "memory-journal-mcp",
-    "version": "7.6.0",
+    "version": "7.6.1",
     "description": "Project context management for AI-assisted development - Persistent knowledge graphs and intelligent context recall across fragmented AI threads",
     "type": "module",
     "main": "dist/index.js",

--- a/releases/v7.6.1.md
+++ b/releases/v7.6.1.md
@@ -1,0 +1,22 @@
+- **Team Collaboration Fixes**: Resolved test failures and internal crashes related to creating, resolving, and searching global team flags by bypassing strict `project_number` multi-tenant requirements for flag-based queries.
+- **Dependency Bumps**: Updated Trivy, CodeQL, TruffleHog, and attest-build-provenance actions to newer versions with SHA-pinned improvements.
+
+### Fixed
+
+- Code Mode and standard test failures when creating, resolving, or searching global team flags by resolving strict `project_number` nullish schema validation errors.
+- Internal crash in `team_search` and `team_search_by_date_range` when filtering global flags by conditionally bypassing the strict multi-tenant `project_number` requirements when explicitly searching for `flag:` tags or `entry_type === 'flag'`.
+
+### CI/CD
+
+- Bumped `aquasecurity/trivy-action` from `v0.35.0` to `v0.36.0`.
+- Bumped `github/codeql-action` from `v4.35.1` to `v4.35.2`.
+- Bumped `trufflesecurity/trufflehog` from `v3.94.3` to `v3.95.2`.
+- Bumped `actions/attest-build-provenance` from `v2` to `v4.1.0` (SHA-pinned).
+
+---
+
+[Compare with v7.6.0](https://github.com/neverinfamous/memory-journal-mcp/compare/v7.6.0...v7.6.1)
+
+```bash
+npm install -g memory-journal-mcp@7.6.1
+```

--- a/src/auth/oauth-resource-server.ts
+++ b/src/auth/oauth-resource-server.ts
@@ -93,7 +93,10 @@ export class OAuthResourceServer {
      */
     getWWWAuthenticateHeader(error?: string, errorDescription?: string): string {
         const escapeHeaderValue = (str: string): string =>
-            str.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/[\r\n]/g, ' ')
+            str
+                .replace(/\\/g, '\\\\')
+                .replace(/"/g, '\\"')
+                .replace(/[\r\n]/g, ' ')
         const parts = [`Bearer realm="${escapeHeaderValue(this.config.resource)}"`]
 
         if (error) {

--- a/src/handlers/resources/core/briefing/github-section.ts
+++ b/src/handlers/resources/core/briefing/github-section.ts
@@ -289,12 +289,10 @@ async function fetchIssuesAndPrs(
         const openIssues = issues.length > 0 ? issues.length : 0
         const openIssueList =
             config.issueCount > 0 && issues.length > 0
-                ? issues
-                      .slice(0, config.issueCount)
-                      .map((i) => ({
-                          number: i.number,
-                          title: markUntrustedContentInline(i.title),
-                      }))
+                ? issues.slice(0, config.issueCount).map((i) => ({
+                      number: i.number,
+                      title: markUntrustedContentInline(i.title),
+                  }))
                 : undefined
 
         const prState = config.prStatusBreakdown ? ('all' as const) : ('open' as const)

--- a/src/handlers/resources/core/utilities.ts
+++ b/src/handlers/resources/core/utilities.ts
@@ -197,12 +197,11 @@ export const rulesResource: InternalResourceDef = {
                     timestamp: Date.now(),
                 })
 
-            // Bounded cache
-            if (cachedRulesMap.size > 100) {
-                const firstKey = cachedRulesMap.keys().next().value
-                if (firstKey) cachedRulesMap.delete(firstKey)
-            }
-
+                // Bounded cache
+                if (cachedRulesMap.size > 100) {
+                    const firstKey = cachedRulesMap.keys().next().value
+                    if (firstKey) cachedRulesMap.delete(firstKey)
+                }
             } finally {
                 await file.close()
             }
@@ -211,7 +210,9 @@ export const rulesResource: InternalResourceDef = {
             return {
                 data: cachedData ? cachedData.content : '',
                 annotations: {
-                    lastModified: new Date(cachedData ? cachedData.timestamp : Date.now()).toISOString(),
+                    lastModified: new Date(
+                        cachedData ? cachedData.timestamp : Date.now()
+                    ).toISOString(),
                 },
             }
         } catch (err) {

--- a/src/handlers/tools/team/admin-tools.ts
+++ b/src/handlers/tools/team/admin-tools.ts
@@ -47,7 +47,10 @@ export function getTeamAdminTools(context: ToolContext): ToolDefinition[] {
 
                     // Verify entry exists and belongs to the project (if project_number is specified)
                     const existing = teamDb.getEntryById(entry_id)
-                    if (!existing || (project_number !== undefined && existing.projectNumber !== project_number)) {
+                    if (
+                        !existing ||
+                        (project_number !== undefined && existing.projectNumber !== project_number)
+                    ) {
                         return {
                             success: false,
                             error: `Team entry ${String(entry_id)} not found or lacks permission for project ${project_number}`,
@@ -113,7 +116,10 @@ export function getTeamAdminTools(context: ToolContext): ToolDefinition[] {
 
                     // Verify entry exists and belongs to project (if project_number is specified)
                     const existing = teamDb.getEntryById(entry_id)
-                    if (!existing || (project_number !== undefined && existing.projectNumber !== project_number)) {
+                    if (
+                        !existing ||
+                        (project_number !== undefined && existing.projectNumber !== project_number)
+                    ) {
                         return {
                             success: false,
                             error: `Team entry ${String(entry_id)} not found or lacks permission for project ${project_number}`,

--- a/src/handlers/tools/team/core-tools.ts
+++ b/src/handlers/tools/team/core-tools.ts
@@ -24,12 +24,14 @@ import {
     TeamTagsListOutputSchema,
 } from './schemas.js'
 
-function parseFlagContext(autoContext: string | null | undefined): Record<string, unknown> | undefined {
-    if (!autoContext) return undefined;
+function parseFlagContext(
+    autoContext: string | null | undefined
+): Record<string, unknown> | undefined {
+    if (!autoContext) return undefined
     try {
-        return JSON.parse(autoContext) as Record<string, unknown>;
+        return JSON.parse(autoContext) as Record<string, unknown>
     } catch {
-        return undefined;
+        return undefined
     }
 }
 
@@ -133,9 +135,7 @@ export function getTeamCoreTools(context: ToolContext): ToolDefinition[] {
                     teamDb.flushSave()
 
                     const parsedFlagMetadata =
-                        entry.entryType === 'flag'
-                            ? parseFlagContext(entry.autoContext)
-                            : undefined
+                        entry.entryType === 'flag' ? parseFlagContext(entry.autoContext) : undefined
 
                     return {
                         success: true,
@@ -166,7 +166,10 @@ export function getTeamCoreTools(context: ToolContext): ToolDefinition[] {
                         TeamGetEntryByIdSchema.parse(params)
                     const entry = teamDb.getEntryById(entry_id)
 
-                    if (!entry || (project_number !== undefined && entry.projectNumber !== project_number)) {
+                    if (
+                        !entry ||
+                        (project_number !== undefined && entry.projectNumber !== project_number)
+                    ) {
                         return {
                             success: false,
                             error: `Team entry ${String(entry_id)} not found or does not belong to project ${project_number}`,
@@ -180,9 +183,7 @@ export function getTeamCoreTools(context: ToolContext): ToolDefinition[] {
 
                     const author = fetchAuthor(teamDb, entry_id)
                     const parsedFlagMetadata =
-                        entry.entryType === 'flag'
-                            ? parseFlagContext(entry.autoContext)
-                            : undefined
+                        entry.entryType === 'flag' ? parseFlagContext(entry.autoContext) : undefined
                     const enrichedEntry = { ...entry, author, flagMetadata: parsedFlagMetadata }
 
                     const result: Record<string, unknown> = {
@@ -233,9 +234,7 @@ export function getTeamCoreTools(context: ToolContext): ToolDefinition[] {
                         ...e,
                         author: authorMap.get(e.id) ?? null,
                         flagMetadata:
-                            e.entryType === 'flag'
-                                ? parseFlagContext(e.autoContext)
-                                : undefined,
+                            e.entryType === 'flag' ? parseFlagContext(e.autoContext) : undefined,
                     }))
 
                     return { entries: enriched, count: enriched.length }

--- a/src/handlers/tools/team/core-tools.ts
+++ b/src/handlers/tools/team/core-tools.ts
@@ -23,17 +23,7 @@ import {
     TeamEntryDetailOutputSchema,
     TeamTagsListOutputSchema,
 } from './schemas.js'
-
-function parseFlagContext(
-    autoContext: string | null | undefined
-): Record<string, unknown> | undefined {
-    if (!autoContext) return undefined
-    try {
-        return JSON.parse(autoContext) as Record<string, unknown>
-    } catch {
-        return undefined
-    }
-}
+import { parseFlagContext } from '../../../types/auto-context.js'
 
 // ============================================================================
 // Tool Definitions

--- a/src/handlers/tools/team/search-tools.ts
+++ b/src/handlers/tools/team/search-tools.ts
@@ -42,7 +42,13 @@ export function getTeamSearchTools(context: ToolContext): ToolDefinition[] {
                     const { query, tags, limit, sort_by, project_number } =
                         TeamSearchSchema.parse(params)
 
-                    const isGlobalFlagSearch = tags?.some((t) => t.startsWith('flag:'))
+                    // Security: To bypass project_number, the search must explicitly be for flags only.
+                    // Prevent mixed tag arrays (e.g. ['flag:blocker', 'frontend']) from leaking non-flag entries
+                    // because tag filtering is an OR/IN operation.
+                    const isGlobalFlagSearch =
+                        tags !== undefined &&
+                        tags.length > 0 &&
+                        tags.every((t) => t.startsWith('flag:'))
 
                     if (project_number == null && !isGlobalFlagSearch) {
                         return {
@@ -68,6 +74,11 @@ export function getTeamSearchTools(context: ToolContext): ToolDefinition[] {
                         sortBy: sort_by,
                         projectNumber: project_number,
                     })
+
+                    // Security: Enforce entryType constraint for cross-tenant searches
+                    if (project_number == null) {
+                        entries = entries.filter((e) => e.entryType === 'flag')
+                    }
 
                     // Filter by tags if provided (batch query instead of N+1)
                     if (tags && tags.length > 0) {
@@ -130,8 +141,12 @@ export function getTeamSearchTools(context: ToolContext): ToolDefinition[] {
                         project_number,
                     } = TeamSearchByDateRangeSchema.parse(params)
 
+                    // Security: To bypass project_number, the search must explicitly be for flags only.
                     const isGlobalFlagSearch =
-                        entry_type === 'flag' || tags?.some((t) => t.startsWith('flag:'))
+                        entry_type === 'flag' ||
+                        (tags !== undefined &&
+                            tags.length > 0 &&
+                            tags.every((t) => t.startsWith('flag:')))
 
                     if (project_number == null && !isGlobalFlagSearch) {
                         return {
@@ -160,7 +175,8 @@ export function getTeamSearchTools(context: ToolContext): ToolDefinition[] {
                     }
 
                     const entries = teamDb.searchByDateRange(start_date, end_date, {
-                        entryType: entry_type,
+                        // Security: Enforce entryType constraint for cross-tenant searches
+                        entryType: project_number == null ? 'flag' : entry_type,
                         tags,
                         limit,
                         sortBy: sort_by,

--- a/src/handlers/tools/team/search-tools.ts
+++ b/src/handlers/tools/team/search-tools.ts
@@ -42,7 +42,7 @@ export function getTeamSearchTools(context: ToolContext): ToolDefinition[] {
                     const { query, tags, limit, sort_by, project_number } =
                         TeamSearchSchema.parse(params)
 
-                    const isGlobalFlagSearch = tags?.some(t => t.startsWith('flag:'))
+                    const isGlobalFlagSearch = tags?.some((t) => t.startsWith('flag:'))
 
                     if (project_number == null && !isGlobalFlagSearch) {
                         return {
@@ -130,7 +130,8 @@ export function getTeamSearchTools(context: ToolContext): ToolDefinition[] {
                         project_number,
                     } = TeamSearchByDateRangeSchema.parse(params)
 
-                    const isGlobalFlagSearch = entry_type === 'flag' || tags?.some(t => t.startsWith('flag:'))
+                    const isGlobalFlagSearch =
+                        entry_type === 'flag' || tags?.some((t) => t.startsWith('flag:'))
 
                     if (project_number == null && !isGlobalFlagSearch) {
                         return {

--- a/src/transports/http/server/index.ts
+++ b/src/transports/http/server/index.ts
@@ -288,17 +288,14 @@ export class HttpTransport {
             // Defeat CodeQL AST heuristics that falsely flag this as an un-rate-limited auth endpoint
             const reqRecord = req as unknown as Record<string, unknown>
             const d = reqRecord[['a', 'u', 't', 'h'].join('')] as TokenClaims | undefined
-            
+
             if (d !== undefined && d !== null) {
-                propagateCtx(
-                    { authenticated: true, claims: d, scopes: d.scopes },
-                    next
-                )
+                propagateCtx({ authenticated: true, claims: d, scopes: d.scopes }, next)
             } else {
                 next()
             }
         }
-        
+
         /* codeql[js/missing-rate-limiting] */ this.app.use(propagateContextMiddleware)
 
         // Scope enforcement middleware

--- a/tests/auth/authorization-server-discovery.test.ts
+++ b/tests/auth/authorization-server-discovery.test.ts
@@ -5,7 +5,6 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import * as https from 'node:https'
 import { EventEmitter } from 'node:events'
 import {
     AuthorizationServerDiscovery,

--- a/tests/codemode/security.test.ts
+++ b/tests/codemode/security.test.ts
@@ -10,7 +10,6 @@
 
 import { describe, it, expect, beforeEach } from 'vitest'
 import { CodeModeSecurityManager, DEFAULT_SECURITY_CONFIG } from '../../src/codemode/index.js'
-import * as v8 from 'node:v8'
 
 describe('CodeModeSecurityManager', () => {
     let security: CodeModeSecurityManager

--- a/tests/e2e/oauth-scopes.spec.ts
+++ b/tests/e2e/oauth-scopes.spec.ts
@@ -49,10 +49,6 @@ test.describe('OAuth 2.1 Scope Enforcement E2E', () => {
 
         // 2. Start mock JWKS HTTP server
         const app = express()
-        app.use((req, res, next) => {
-            console.log('JWKS Mock Received:', req.method, req.url)
-            next()
-        })
         app.get('/jwks', (req, res) => {
             res.json({ keys: [jwk] })
         })

--- a/tests/e2e/team-isolation.spec.ts
+++ b/tests/e2e/team-isolation.spec.ts
@@ -42,4 +42,37 @@ test.describe('Payload Contracts: Team Isolation', () => {
         expect(payload.code).toBe('PERMISSION_DENIED')
         expect(payload.error).toContain('MUST specify a project_number')
     })
+
+    test('team_search MUST bypass project_number constraint for pure flag searches', async () => {
+        const payload = await callToolAndParse(client, 'team_search', {
+            query: 'test',
+            tags: ['flag:blocker'],
+        })
+
+        expect(payload.success).toBe(true)
+        // ensure it filtered correctly under the hood
+        if (payload.entries.length > 0) {
+            expect(payload.entries[0].entryType).toBe('flag')
+        }
+    })
+
+    test('team_search MUST reject queries without project_number if tags contain non-flags', async () => {
+        const payload = await callToolAndParse(client, 'team_search', {
+            query: 'test',
+            tags: ['flag:blocker', 'frontend'],
+        })
+
+        expect(payload.success).toBe(false)
+        expect(payload.code).toBe('PERMISSION_DENIED')
+    })
+
+    test('team_search_by_date_range MUST bypass project_number constraint for flag entry_type', async () => {
+        const payload = await callToolAndParse(client, 'team_search_by_date_range', {
+            start_date: '2020-01-01',
+            end_date: '2030-12-31',
+            entry_type: 'flag',
+        })
+
+        expect(payload.success).toBe(true)
+    })
 })

--- a/tests/handlers/catch-block-coverage.test.ts
+++ b/tests/handlers/catch-block-coverage.test.ts
@@ -10,7 +10,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import { callTool as _callTool } from '../../src/handlers/tools/index.js'
 import { DatabaseAdapter } from '../../src/database/sqlite-adapter/index.js'
-import * as fs from 'node:fs'
 
 const callTool = (
     name: any,

--- a/tests/handlers/targeted-gap-closure-2.test.ts
+++ b/tests/handlers/targeted-gap-closure-2.test.ts
@@ -16,7 +16,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import { callTool as _callTool } from '../../src/handlers/tools/index.js'
 import { DatabaseAdapter } from '../../src/database/sqlite-adapter/index.js'
-import * as fs from 'node:fs'
 
 const callTool = (
     name: any,

--- a/tests/handlers/team-data.test.ts
+++ b/tests/handlers/team-data.test.ts
@@ -7,9 +7,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import { callTool as _callTool } from '../../src/handlers/tools/index.js'
 import { DatabaseAdapter } from '../../src/database/sqlite-adapter/index.js'
-import * as fs from 'node:fs'
-import * as path from 'node:path'
-import * as os from 'node:os'
 
 const callTool = (
     name: any,

--- a/tests/server/mcp-server.test.ts
+++ b/tests/server/mcp-server.test.ts
@@ -666,7 +666,7 @@ describe('McpServer', function () {
             const spyCall = vi.spyOn(toolsModule, 'callTool').mockResolvedValueOnce({
                 invalidField: 10n,
             })
-            const server = await createServer({ transport: 'stdio', dbPath: './test-server.db' })
+            await createServer({ transport: 'stdio', dbPath: './test-server.db' })
 
             const toolCalls = mockRegisterTool.mock.calls.filter(
                 (call: unknown[]) => call[0] === 'fake_boom_tool'


### PR DESCRIPTION
- **Team Collaboration Fixes**: Resolved test failures and internal crashes related to creating, resolving, and searching global team flags by bypassing strict `project_number` multi-tenant requirements for flag-based queries.
- **Dependency Bumps**: Updated Trivy, CodeQL, TruffleHog, and attest-build-provenance actions to newer versions with SHA-pinned improvements.

### Fixed

- Code Mode and standard test failures when creating, resolving, or searching global team flags by resolving strict `project_number` nullish schema validation errors.
- Internal crash in `team_search` and `team_search_by_date_range` when filtering global flags by conditionally bypassing the strict multi-tenant `project_number` requirements when explicitly searching for `flag:` tags or `entry_type === 'flag'`.

### CI/CD

- Bumped `aquasecurity/trivy-action` from `v0.35.0` to `v0.36.0`.
- Bumped `github/codeql-action` from `v4.35.1` to `v4.35.2`.
- Bumped `trufflesecurity/trufflehog` from `v3.94.3` to `v3.95.2`.
- Bumped `actions/attest-build-provenance` from `v2` to `v4.1.0` (SHA-pinned).

---

[Compare with v7.6.0](https://github.com/neverinfamous/memory-journal-mcp/compare/v7.6.0...v7.6.1)

```bash
npm install -g memory-journal-mcp@7.6.1
```
