### PR TITLE
fix: compile sqlite-vec from source on alpine to eliminate CVEs

### DIFF
--- a/.github/workflows/ci-health-monitor.lock.yml
+++ b/.github/workflows/ci-health-monitor.lock.yml
@@ -227,7 +227,7 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/print_prompt_summary.sh
       - name: Upload activation artifact
         if: success()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: activation
           path: |
@@ -709,7 +709,7 @@ jobs:
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: agent
           path: |
@@ -726,7 +726,7 @@ jobs:
       - name: Upload firewall audit logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: firewall-audit-logs
           path: |
@@ -956,7 +956,7 @@ jobs:
           XDG_CONFIG_HOME: /home/runner
       - name: Upload threat detection log
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: detection
           path: /tmp/gh-aw/threat-detection/detection.log
@@ -1045,7 +1045,7 @@ jobs:
             await main();
       - name: Upload Safe Output Items
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Docker Scout security scan
-        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
+        uses: docker/scout-action@cd72f264beff1cd72735de31148b9d3244a0234a # v1.20.4
         timeout-minutes: 10
         with:
           command: cves

--- a/.github/workflows/docs-drift-detector.lock.yml
+++ b/.github/workflows/docs-drift-detector.lock.yml
@@ -245,7 +245,7 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/print_prompt_summary.sh
       - name: Upload activation artifact
         if: success()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: activation
           path: |
@@ -710,7 +710,7 @@ jobs:
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: agent
           path: |
@@ -727,7 +727,7 @@ jobs:
       - name: Upload firewall audit logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: firewall-audit-logs
           path: |
@@ -958,7 +958,7 @@ jobs:
           XDG_CONFIG_HOME: /home/runner
       - name: Upload threat detection log
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: detection
           path: /tmp/gh-aw/threat-detection/detection.log
@@ -1072,7 +1072,7 @@ jobs:
             await main();
       - name: Upload Safe Output Items
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl

--- a/.github/workflows/wiki-drift-detector.lock.yml
+++ b/.github/workflows/wiki-drift-detector.lock.yml
@@ -245,7 +245,7 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/print_prompt_summary.sh
       - name: Upload activation artifact
         if: success()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: activation
           path: |
@@ -710,7 +710,7 @@ jobs:
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: agent
           path: |
@@ -727,7 +727,7 @@ jobs:
       - name: Upload firewall audit logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: firewall-audit-logs
           path: |
@@ -958,7 +958,7 @@ jobs:
           XDG_CONFIG_HOME: /home/runner
       - name: Upload threat detection log
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: detection
           path: /tmp/gh-aw/threat-detection/detection.log
@@ -1072,7 +1072,7 @@ jobs:
             await main();
       - name: Upload Safe Output Items
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # Install build dependencies and upgrade packages for security
 # Use Alpine edge for latest security patches (curl CVE-2025-14524, zlib CVE-2026-27171, etc.)
-RUN apk add --no-cache python3 make g++ && \
+RUN apk add --no-cache python3 make g++ gettext git sqlite-dev && \
     apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main curl zlib libcrypto3 libssl3 nghttp2-libs && \
     apk upgrade --no-cache
 
@@ -36,6 +36,10 @@ RUN npm run build
 # We use v0.1.7-alpha.2 to match the package.json version
 RUN curl -L https://github.com/asg017/sqlite-vec/archive/refs/tags/v0.1.7-alpha.2.tar.gz | tar -xz && \
     cd sqlite-vec-0.1.7-alpha.2 && \
+    sed -i 's/typedef u_int8_t uint8_t;//g' sqlite-vec.c && \
+    sed -i 's/typedef u_int16_t uint16_t;//g' sqlite-vec.c && \
+    sed -i 's/typedef u_int32_t uint32_t;//g' sqlite-vec.c && \
+    sed -i 's/typedef u_int64_t uint64_t;//g' sqlite-vec.c && \
     make loadable && \
     cp dist/vec0.so /app/vec0.so && \
     cd .. && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 # Memory Journal MCP Server - TypeScript Version
 # Multi-stage build for optimized production image
-FROM node:26.2.0-bookworm-slim AS builder
+FROM node:26.2.0-alpine AS builder
 
 WORKDIR /app
 
 # Install build dependencies and upgrade packages for security
-# Debian bookworm-slim receives regular security updates. Upgrade them all to patch CVEs.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 make g++ curl libssl-dev && \
-    apt-get upgrade -y && \
-    rm -rf /var/lib/apt/lists/*
+# Use Alpine edge for latest security patches (curl CVE-2025-14524, zlib CVE-2026-27171, etc.)
+RUN apk add --no-cache python3 make g++ && \
+    apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main curl zlib libcrypto3 libssl3 nghttp2-libs && \
+    apk upgrade --no-cache
 
 # Upgrade npm globally to a pinned version to ensure reproducible builds
 # Fixes CVE-2025-64756 (glob), CVE-2025-64118 (tar)
@@ -33,6 +32,15 @@ COPY src/ ./src/
 # Build TypeScript
 RUN npm run build
 
+# Compile sqlite-vec native extension from source for Alpine (musl libc)
+# We use v0.1.7-alpha.2 to match the package.json version
+RUN curl -L https://github.com/asg017/sqlite-vec/archive/refs/tags/v0.1.7-alpha.2.tar.gz | tar -xz && \
+    cd sqlite-vec-0.1.7-alpha.2 && \
+    make loadable && \
+    cp dist/vec0.so /app/vec0.so && \
+    cd .. && \
+    rm -rf sqlite-vec-0.1.7-alpha.2
+
 # Install production-only dependencies in a separate directory for clean copy
 RUN mkdir /app/prod_modules && \
     cp package*.json .npmrc /app/prod_modules/ && \
@@ -50,20 +58,22 @@ RUN rm -rf /app/prod_modules/node_modules/onnxruntime-web \
            /app/prod_modules/node_modules/onnxruntime-node/bin/napi-v3/win32
 
 # Production stage
-FROM node:26.2.0-bookworm-slim
+FROM node:26.2.0-alpine
 
 WORKDIR /app
 
 # Install runtime dependencies with security fixes
-# Debian bookworm-slim receives regular security updates. Upgrade them all to patch CVEs.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git ca-certificates curl && \
-    apt-get upgrade -y && \
-    rm -rf /var/lib/apt/lists/* && \
+# Use Alpine edge for curl with CVE fixes (and nghttp2-libs for CVE-2026-27135)
+# Explicit libexpat upgrade for CVE-2026-24515 (CRITICAL) and CVE-2026-25210 (MEDIUM)
+# Explicit zlib upgrade for CVE-2026-27171 (MEDIUM)
+RUN apk add --no-cache git ca-certificates && \
+    apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main curl libexpat zlib libcrypto3 libssl3 nghttp2-libs && \
+    apk upgrade --no-cache && \
     rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
-# Copy built artifacts and production dependencies from builder
+# Copy built artifacts, sqlite-vec, and production dependencies from builder
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/vec0.so ./vec0.so
 COPY --from=builder /app/prod_modules/node_modules ./node_modules
 COPY package*.json ./
 COPY LICENSE ./
@@ -72,8 +82,8 @@ COPY LICENSE ./
 RUN mkdir -p /app/data && chmod 700 /app/data
 
 # Create non-root user for security
-RUN groupadd -g 1001 appgroup && \
-    useradd -u 1001 -g appgroup -s /bin/sh -m appuser && \
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup && \
     chown -R appuser:appgroup /app
 
 # Set environment variables

--- a/src/database/sqlite-adapter/native-connection.ts
+++ b/src/database/sqlite-adapter/native-connection.ts
@@ -70,18 +70,32 @@ export class NativeConnectionManager implements IDatabaseConnection {
 
             // Load sqlite-vec extension for vector search
             // Use local `db` ref to avoid race with concurrent close() during await
-            const sqliteVec = await import('sqlite-vec')
+            try {
+                // Try the npm package first (for local development on macOS/Windows/glibc)
+                const sqliteVec = await import('sqlite-vec')
 
-            // Guard: if close() was called during the await, abort initialization
-            if (this.db === null) {
-                logger.info('Database closed during initialization, aborting', {
+                // Guard: if close() was called during the await, abort initialization
+                if (this.db === null) {
+                    logger.info('Database closed during initialization, aborting', {
+                        module: 'NativeConnectionManager',
+                    })
+                    return
+                }
+
+                sqliteVec.load(db)
+                logger.info('sqlite-vec extension loaded via npm package', {
                     module: 'NativeConnectionManager',
                 })
-                return
+            } catch {
+                // Fallback: try loading the compiled .so directly (for Alpine Docker)
+                // In production, the .so is placed in /app/vec0.so, so we resolve relative to the process root or a known path.
+                const fallbackPath = path.resolve(process.cwd(), 'vec0')
+                db.loadExtension(fallbackPath)
+                logger.info('sqlite-vec extension loaded via compiled fallback', {
+                    module: 'NativeConnectionManager',
+                    path: fallbackPath,
+                })
             }
-
-            sqliteVec.load(db)
-            logger.info('sqlite-vec extension loaded', { module: 'NativeConnectionManager' })
 
             // Create base schema
             db.exec(SCHEMA_SQL)


### PR DESCRIPTION
Reverts to Alpine Linux to eliminate the 50+ CVEs introduced by Debian Slim, and natively compiles sqlite-vec from C source during the Docker build stage to retain vector database functionality.